### PR TITLE
真偽値の字句解析を実装

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -46,6 +46,11 @@ func strToken(t *testing.T, value string) parser.ValueToken {
 	return parser.NewValueToken(parser.String, value)
 }
 
+func boolToken(t *testing.T, value bool) parser.ValueToken {
+	t.Helper()
+	return parser.NewValueToken(parser.Bool, value)
+}
+
 func TestIntAnalyzer(t *testing.T) {
 	tests := []testCase{
 		{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -51,6 +51,30 @@ func boolToken(t *testing.T, value bool) parser.ValueToken {
 	return parser.NewValueToken(parser.Bool, value)
 }
 
+func TestBoolAnalyzer(t *testing.T) {
+	tests := []testCase{
+		{
+			"真",
+			"true",
+			nil,
+			[]parser.Tokener{boolToken(t, true)},
+		},
+		{
+			"偽",
+			"false",
+			nil,
+			[]parser.Tokener{boolToken(t, false)},
+		},
+		{
+			"定義されていないキーワード[trueeeee]",
+			"trueeeee",
+			parser.ErrUndefinedKeyword,
+			nil,
+		},
+	}
+	runTestCases(t, tests)
+}
+
 func TestIntAnalyzer(t *testing.T) {
 	tests := []testCase{
 		{


### PR DESCRIPTION
tokenとして変換する

- `true` と `false`

tokenとして変換しない

- `"true"` や `True`