### PR TITLE
真偽値でない値が真偽値として解析されることがあるバグを修正 #4

### DIFF
--- a/parser/analyzer_test.go
+++ b/parser/analyzer_test.go
@@ -71,6 +71,18 @@ func TestBoolAnalyzer(t *testing.T) {
 			parser.ErrUndefinedKeyword,
 			nil,
 		},
+		{
+			"定義されていないキーワード[atrue]",
+			"atrue",
+			parser.ErrUndefinedKeyword,
+			nil,
+		},
+		{
+			"定義されていないキーワード[afalse]",
+			"afalse",
+			parser.ErrUndefinedKeyword,
+			nil,
+		},
 	}
 	runTestCases(t, tests)
 }

--- a/parser/analyzer_test.go
+++ b/parser/analyzer_test.go
@@ -68,19 +68,19 @@ func TestBoolAnalyzer(t *testing.T) {
 		{
 			"定義されていないキーワード[trueeeee]",
 			"trueeeee",
-			parser.ErrUndefinedKeyword,
+			parser.ErrUndefinedSymbol,
 			nil,
 		},
 		{
 			"定義されていないキーワード[atrue]",
 			"atrue",
-			parser.ErrUndefinedKeyword,
+			parser.ErrUndefinedSymbol,
 			nil,
 		},
 		{
 			"定義されていないキーワード[afalse]",
 			"afalse",
-			parser.ErrUndefinedKeyword,
+			parser.ErrUndefinedSymbol,
 			nil,
 		},
 	}

--- a/parser/analyzer_test.go
+++ b/parser/analyzer_test.go
@@ -83,6 +83,12 @@ func TestBoolAnalyzer(t *testing.T) {
 			parser.ErrUndefinedSymbol,
 			nil,
 		},
+		{
+			"定義されていないキーワード[true111]",
+			"true111",
+			parser.ErrUndefinedSymbol,
+			nil,
+		},
 	}
 	runTestCases(t, tests)
 }


### PR DESCRIPTION
## 原因

token にできない文字はスキップされていたことが原因。例えば、`atrue` の `a` はスキップされて `t` から解析される処理になっていた。

## 解決策

switch文 に default を追加してスキップしないようにした。例えば、`atrue` の `a` はどの case にも当てはまらないので、default に引っかかる。
また、空白はスキップして欲しいので、スキップするようにした。

close #4 