### PR TITLE
真偽値の字句解析が期待通りに動かない問題を修正 #7

### DIFF
--- a/parser/analyzer.go
+++ b/parser/analyzer.go
@@ -82,13 +82,13 @@ func extractStringAsToken(str string, startIdx int) (ValueToken, int, error) {
 	// 直前に\がない"
 	// または 直前に\が偶数回連続している"
 	// `"`や`\\"`などがマッチ
-	re := regexp.MustCompile(`(?:^|[^\\]|((^|[^\\])(\\\\)+))(")`)
+	re := regexp.MustCompile(`(?:^|[^\\]|(?:(?:^|[^\\])(?:\\\\)+))(")`)
 	loc := re.FindStringSubmatchIndex(str[startIdx+1:])
 	if loc == nil {
 		return ValueToken{}, 0, ErrSyntax
 	}
 	// idxsはstr[firstQuotationIdx+1]からのインデックスであるためfirstQuotationIdx+1を足す
-	endIdx := startIdx + 1 + loc[1]
+	endIdx := startIdx + 1 + loc[3]
 
 	value, err := strconv.Unquote(str[startIdx:endIdx])
 	if err != nil {

--- a/parser/analyzer.go
+++ b/parser/analyzer.go
@@ -152,14 +152,13 @@ func mayBeBool(str string, i int) bool {
 }
 
 func extractBoolAsToken(str string, startIdx int) (ValueToken, int, error) {
-	// ?i: はcase insentive
 	// ?: はグループをキャプチャしない
-	re := regexp.MustCompile(`(?i:true|false)(?:[\s,:"{}\[\]]|$)`)
+	re := regexp.MustCompile(`(true|false)(?:[\s,:"{}\[\]]|$)`)
 	loc := re.FindStringSubmatchIndex(str[startIdx:])
 	if loc == nil {
 		return ValueToken{}, 0, ErrUndefinedSymbol
 	}
-	endIdx := startIdx + loc[1]
+	endIdx := startIdx + loc[3]
 
 	var value bool
 	if str[startIdx:endIdx] == "true" {

--- a/parser/analyzer_test.go
+++ b/parser/analyzer_test.go
@@ -66,6 +66,15 @@ func TestBoolAnalyzer(t *testing.T) {
 			[]parser.Tokener{boolToken(t, false)},
 		},
 		{
+			"真(連続して記号が来る場合)",
+			"true,",
+			nil,
+			[]parser.Tokener{
+				boolToken(t, true),
+				parser.NewMarkToken(parser.Comma),
+			},
+		},
+		{
 			"定義されていないキーワード[trueeeee]",
 			"trueeeee",
 			parser.ErrUndefinedSymbol,


### PR DESCRIPTION
close #7 

## 修正について

正しい capture group の index を使うように修正した。詳しくは #7 を参照。